### PR TITLE
Awsに画像をアップロードする機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,3 +86,4 @@ gem 'active_hash'
 gem 'pry-rails'
 gem 'payjp'
 gem 'gon'
+gem "aws-sdk-s3", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,22 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
+    aws-eventstream (1.3.0)
+    aws-partitions (1.1014.0)
+    aws-sdk-core (3.214.0)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kms (1.96.0)
+      aws-sdk-core (~> 3, >= 3.210.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.174.0)
+      aws-sdk-core (~> 3, >= 3.210.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.10.1)
+      aws-eventstream (~> 1, >= 1.0.2)
     bcrypt (3.1.20)
     bindex (0.8.1)
     bootsnap (1.18.4)
@@ -136,6 +152,7 @@ GEM
     jbuilder (2.13.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    jmespath (1.6.2)
     json (2.7.5)
     language_server-protocol (3.17.0.3)
     logger (1.6.1)
@@ -324,6 +341,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_hash
+  aws-sdk-s3
   bootsnap
   capybara
   debug

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,7 +34,7 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :amazon
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,7 +38,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :amazon
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -10,6 +10,8 @@ amazon:
   service: S3
   region: ap-northeast-1
   bucket: furima-41754
+  access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
+  secret_access_key:  <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
 # Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:
 #   service: S3

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -6,6 +6,10 @@ local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
 
+amazon:
+  service: S3
+  region: ap-northeast-1
+  bucket: furima-41754
 # Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:
 #   service: S3


### PR DESCRIPTION
# What 
1. **S3に画像を保存する機能を追加**
   - `aws-sdk-s3`を導入。
   - `development.rb`と`storage.yml`を編集し、S3を画像保存先に設定。
   - バケット名やリージョンの設定を実施。

2. **環境変数を使用した認証情報の管理**
   - `~/.zshrc`でAccess key IDとSecret access keyを環境変数に設定。
   - `storage.yml`で環境変数を利用して認証情報を記述。

3. **`git-secrets`を用いたセキュリティ対策の導入**
   - `git-secrets`をインストールし、AWSの機密情報が誤ってコミットされないよう設定。
   - GitHub Desktopで`git-secrets`が機能するよう追加設定を実施。
   - 今後作成する全リポジトリに適用されるテンプレートを設定。

---

# Why 
- 現状では画像がローカルストレージに保存されており、スケーラビリティやデータの可用性に課題があるため。
- S3に画像を保存することで、安定した外部ストレージを利用し、大量のデータや高い信頼性に対応可能にする。
- 機密情報（Access key IDやSecret access key）の漏洩を防ぐため、環境変数や`git-secrets`を用いたセキュリティ対策を導入する。
